### PR TITLE
Refactoring phantom type of readwrite

### DIFF
--- a/Sources/AnyRealmIO.swift
+++ b/Sources/AnyRealmIO.swift
@@ -18,12 +18,12 @@ public struct AnyRealmIO<T> {
         return !isRead
     }
 
-    public init(io: RealmIO<Read, T>) {
+    public init(io: RealmIO<ReadOnly, T>) {
         self._run = io._run
         self.isRead = true
     }
 
-    public init(io: RealmIO<Write, T>) {
+    public init(io: RealmIO<ReadWrite, T>) {
         self._run = io._run
         self.isRead = false
     }

--- a/Sources/ReadWrite.swift
+++ b/Sources/ReadWrite.swift
@@ -8,14 +8,21 @@
 
 import Foundation
 
-// MARK: - Read
+// MARK: - ReadWrite
 
-/// `Read` is used as `RW` type parameter of `RealmIO<RW, T>`
-/// It represents that realm operation is readonly.
-public struct Read { }
-
-// MARK: - Write
-
-/// `Write` is used as `RW` type parameter of `RealmIO<RW, T>`
+/// `ReadWrite` is used as `RW` type parameter of `RealmIO<RW, T>`
 /// It represents that realm operation needs to call `realm.write`.
-public struct Write { }
+public class ReadWrite { }
+
+
+// MARK: - ReadOnly
+
+/// `ReadOnly` is used as `RW` type parameter of `RealmIO<RW, T>`
+/// It represents that realm operation is readonly.
+public class ReadOnly: ReadWrite { }
+
+@available(*, deprecated, renamed: "ReadOnly")
+public typealias Read = ReadOnly
+
+@available(*, deprecated, renamed: "ReadWrite")
+public typealias Write = ReadWrite

--- a/Tests/BasicOperatorSpec.swift
+++ b/Tests/BasicOperatorSpec.swift
@@ -21,9 +21,9 @@ class BasicOperatorSpec: QuickSpec {
             it("should throw Error when run io that initalized with `init(error:)`") {
                 struct MyError: Error { }
                 let error = MyError()
-                let read = RealmIO<Read, Void>(error: error)
+                let read = RealmIO<ReadOnly, Void>(error: error)
                 expect { try self.realm.run(io: read) }.to(throwError())
-                let write = RealmIO<Write, Void>(error: error)
+                let write = RealmIO<ReadWrite, Void>(error: error)
                 expect { try self.realm.run(io: write) }.to(throwError())
             }
         }


### PR DESCRIPTION
This pr make RW type more stable, and removing each duplicated implementation.
And I renamed from `Read / Write` to` ReadOnly / ReadWrite`. Please let me know if my naming is not good.